### PR TITLE
feat: added `no-empty-block` linter rule to be ignored

### DIFF
--- a/lib/src/full_coverage_base.dart
+++ b/lib/src/full_coverage_base.dart
@@ -58,7 +58,7 @@ class FullCoverage {
     }
 
     final buffer = StringBuffer();
-    buffer.writeln('// ignore_for_file: unused_import');
+    buffer.writeln('// ignore_for_file: unused_import, no-empty-block');
 
     for (var item in importList) {
       buffer.writeln(item);


### PR DESCRIPTION
![Captura de Tela 2023-06-30 às 21 29 15](https://github.com/Flutterando/full_coverage/assets/54218517/2c102fff-e339-4047-9c88-31a4d88f6e56)